### PR TITLE
フラグメントの画面遷移のみ

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="$USER_HOME$/.android/avd/Pixel_5_API_31_2.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-10-07T01:24:38.134516Z" />
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.2'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.5.2'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'androidx.navigation.safeargs'
 }
 
 android {
@@ -30,20 +31,43 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
-    buildFeatures{
+    buildFeatures {
         viewBinding = true
     }
 }
 
 dependencies {
+    def nav_version = "2.5.2"
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.5.1'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.2'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.5.2'
+    implementation("androidx.navigation:navigation-fragment-ktx:$nav_version")
+    implementation("androidx.navigation:navigation-ui-ktx:$nav_version")
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+
+    //spreadsheet
+    implementation 'com.google.apis:google-api-services-sheets:v4-rev516-1.23.0'
+    implementation 'com.google.api-client:google-api-client-android:1.23.0'
+
+    implementation 'com.google.android.gms:play-services-auth:19.0.0'
+
+    // coroutine
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
+
+    // Retrofit
+//    def retrofit_version = '2.9.0'
+//    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
+//    implementation "com.squareup.retrofit2:converter-moshi:$retrofit_version"
+//
+//    // Moshi
+//    def moshi_version = '1.12.0'
+//    implementation "com.squareup.moshi:moshi:$moshi_version"
+//    implementation "com.squareup.moshi:moshi-kotlin:$moshi_version"
+
+    //Duplicate class対策
+    implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/quizapp/MainActivity.kt
+++ b/app/src/main/java/com/example/quizapp/MainActivity.kt
@@ -2,10 +2,15 @@ package com.example.quizapp
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import com.example.quizapp.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityMainBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
     }
 }

--- a/app/src/main/java/com/example/quizapp/MakeQuizFragment.kt
+++ b/app/src/main/java/com/example/quizapp/MakeQuizFragment.kt
@@ -5,6 +5,7 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.navigation.fragment.findNavController
 import com.example.quizapp.databinding.FragmentMakeQuizBinding
 
 class MakeQuizFragment : Fragment() {
@@ -22,5 +23,13 @@ class MakeQuizFragment : Fragment() {
     ): View? {
         _binding = FragmentMakeQuizBinding.inflate(inflater, container, false)
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.finishMakeQuizButton.setOnClickListener{
+            findNavController().navigate(R.id.action_makeQuizFragment_to_titleFragment)
+        }
     }
 }

--- a/app/src/main/java/com/example/quizapp/MakeQuizFragment.kt
+++ b/app/src/main/java/com/example/quizapp/MakeQuizFragment.kt
@@ -1,0 +1,27 @@
+package com.example.quizapp
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.example.quizapp.databinding.FragmentMakeQuizBinding
+
+class MakeQuizFragment : Fragment() {
+
+    private var _binding: FragmentMakeQuizBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentMakeQuizBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+}

--- a/app/src/main/java/com/example/quizapp/MakeQuizFragment.kt
+++ b/app/src/main/java/com/example/quizapp/MakeQuizFragment.kt
@@ -14,7 +14,6 @@ class MakeQuizFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/example/quizapp/TitleFragment.kt
+++ b/app/src/main/java/com/example/quizapp/TitleFragment.kt
@@ -1,0 +1,46 @@
+package com.example.quizapp
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.navigation.Navigation
+import com.example.quizapp.databinding.FragmentTitleBinding
+
+class TitleFragment : Fragment() {
+
+    private var _binding: FragmentTitleBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentTitleBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.makeQuizButton.setOnClickListener(
+            Navigation.createNavigateOnClickListener(
+                R.id.makeQuizFragment,
+                null
+            )
+        )
+
+        binding.tryQuizButton.setOnClickListener(
+            Navigation.createNavigateOnClickListener(
+                R.id.tryQuizFragment,
+                null
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/example/quizapp/TitleFragment.kt
+++ b/app/src/main/java/com/example/quizapp/TitleFragment.kt
@@ -5,7 +5,7 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.navigation.Navigation
+import androidx.navigation.fragment.findNavController
 import com.example.quizapp.databinding.FragmentTitleBinding
 
 class TitleFragment : Fragment() {
@@ -28,18 +28,14 @@ class TitleFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.makeQuizButton.setOnClickListener(
-            Navigation.createNavigateOnClickListener(
-                R.id.makeQuizFragment,
-                null
-            )
-        )
+        binding.makeQuizButton.setOnClickListener {
+            //MakeQuizFragmentの画面に遷移
+            findNavController().navigate(R.id.action_titleFragment_to_makeQuizFragment)
+        }
 
-        binding.tryQuizButton.setOnClickListener(
-            Navigation.createNavigateOnClickListener(
-                R.id.tryQuizFragment,
-                null
-            )
-        )
+        binding.tryQuizButton.setOnClickListener {
+            //TryQuizFragmentの画面に遷移
+            findNavController().navigate(R.id.action_titleFragment_to_tryQuizFragment)
+        }
     }
 }

--- a/app/src/main/java/com/example/quizapp/TitleFragment.kt
+++ b/app/src/main/java/com/example/quizapp/TitleFragment.kt
@@ -15,7 +15,6 @@ class TitleFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/example/quizapp/TryQuizFragment.kt
+++ b/app/src/main/java/com/example/quizapp/TryQuizFragment.kt
@@ -1,0 +1,26 @@
+package com.example.quizapp
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.example.quizapp.databinding.FragmentTryQuizBinding
+
+class TryQuizFragment : Fragment() {
+
+    private var _binding: FragmentTryQuizBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentTryQuizBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,5 +14,4 @@
         app:defaultNavHost="true"
         app:navGraph="@navigation/nav_graph" />
 
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,13 +6,13 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragmentContainerView"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="true"
+        app:navGraph="@navigation/nav_graph" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_make_quiz.xml
+++ b/app/src/main/res/layout/fragment_make_quiz.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraintLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MakeQuizFragment">
+
+    <TextView
+        android:id="@+id/make_quiz_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:text="@string/make_quiz_text"
+        android:textSize="25dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <EditText
+        android:id="@+id/input_quiz"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:hint="@string/input_quiz_hint"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/make_quiz_text" />
+
+    <TextView
+        android:id="@+id/make_answer_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="30dp"
+        android:text="@string/make_answer_text"
+        android:textSize="25dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/input_quiz" />
+
+    <TextView
+        android:id="@+id/input_answer_hint"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:text="@string/input_answer_hint"
+        android:textSize="15dp"
+        app:layout_constraintStart_toStartOf="@+id/make_answer_text"
+        app:layout_constraintTop_toBottomOf="@+id/make_answer_text" />
+
+    <RadioGroup
+        android:id="@+id/input_answer_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:orientation="vertical"
+        app:layout_constraintStart_toStartOf="@+id/input_answer_hint"
+        app:layout_constraintTop_toBottomOf="@+id/input_answer_hint">
+
+        <RadioButton
+            android:id="@+id/answer_a"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp" />
+
+        <RadioButton
+            android:id="@+id/answer_b"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp" />
+
+        <RadioButton
+            android:id="@+id/answer_c"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp" />
+
+        <RadioButton
+            android:id="@+id/answer_d"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp" />
+
+    </RadioGroup>
+
+    <LinearLayout
+        android:id="@+id/linear"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="@+id/input_quiz"
+        app:layout_constraintStart_toEndOf="@+id/input_answer_button"
+        app:layout_constraintTop_toTopOf="@+id/input_answer_button">
+
+        <EditText
+            android:id="@+id/answer_a_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/answer_a_hint" />
+
+        <EditText
+            android:id="@+id/answer_b_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/answer_b_hint" />
+
+        <EditText
+            android:id="@+id/answer_c_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/answer_c_hint" />
+
+        <EditText
+            android:id="@+id/answer_d_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/answer_d_hint" />
+
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/finish_make_quiz_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="@string/finish_make_quiz_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/continue_make_quiz_button"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
+        android:id="@+id/continue_make_quiz_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="@string/continue_make_quiz_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/finish_make_quiz_button" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_title.xml
+++ b/app/src/main/res/layout/fragment_title.xml
@@ -19,6 +19,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <com.google.android.gms.common.SignInButton
+        android:id="@+id/sign_in_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="40dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView"
+        app:layout_constraintBottom_toTopOf="@+id/make_quiz_button"/>
+
     <Button
         android:id="@+id/make_quiz_button"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_title.xml
+++ b/app/src/main/res/layout/fragment_title.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraintLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".TitleFragment">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/enjoy_quiz"
+        android:textAlignment="center"
+        android:textSize="30sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/make_quiz_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/make_quiz_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/try_quiz_button"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginBottom="30dp"/>
+
+    <Button
+        android:id="@+id/try_quiz_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/try_quiz_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/make_quiz_button"
+        android:layout_marginBottom="30dp"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_try_quiz.xml
+++ b/app/src/main/res/layout/fragment_try_quiz.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraintLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".TryQuizFragment">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Answer the Quiz"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/titleFragment">
+
+    <fragment
+        android:id="@+id/titleFragment"
+        android:name="com.example.quizapp.TitleFragment"
+        android:label="fragment_title"
+        tools:layout="@layout/fragment_title" >
+        <action
+            android:id="@+id/action_titleFragment_to_makeQuizFragment"
+            app:destination="@id/makeQuizFragment" />
+        <action
+            android:id="@+id/action_titleFragment_to_tryQuizFragment"
+            app:destination="@id/tryQuizFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/makeQuizFragment"
+        android:name="com.example.quizapp.MakeQuizFragment"
+        android:label="fragment_make_quiz"
+        tools:layout="@layout/fragment_make_quiz" />
+    <fragment
+        android:id="@+id/tryQuizFragment"
+        android:name="com.example.quizapp.TryQuizFragment"
+        android:label="fragment_try_quiz"
+        tools:layout="@layout/fragment_try_quiz" />
+</navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -21,7 +21,11 @@
         android:id="@+id/makeQuizFragment"
         android:name="com.example.quizapp.MakeQuizFragment"
         android:label="fragment_make_quiz"
-        tools:layout="@layout/fragment_make_quiz" />
+        tools:layout="@layout/fragment_make_quiz" >
+        <action
+            android:id="@+id/action_makeQuizFragment_to_titleFragment"
+            app:destination="@id/titleFragment" />
+    </fragment>
     <fragment
         android:id="@+id/tryQuizFragment"
         android:name="com.example.quizapp.TryQuizFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,16 @@
 <resources>
     <string name="app_name">QuizApp</string>
+    <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="enjoy_quiz">Enjoy Quiz!!</string>
+    <string name="make_quiz_text">問題入力</string>
+    <string name="try_quiz_button">答える</string>
+    <string name="make_answer_text">解答入力</string>
+    <string name="input_quiz_hint">問題を入力してください。</string>
+    <string name="input_answer_hint">正解の選択肢にチェックを入れてね</string>
+    <string name="answer_a_hint">Aの答えを入力</string>
+    <string name="answer_b_hint">Bの答えを入力</string>
+    <string name="answer_c_hint">Cの答えを入力</string>
+    <string name="answer_d_hint">Dの答えを入力</string>
+    <string name="finish_make_quiz_button">問題作成終了</string>
+    <string name="continue_make_quiz_button">続けて問題作成</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    repositories {
+        google()
+    }
+    dependencies {
+        def nav_version = "2.5.2"
+        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version")
+    }
+}
+
 plugins {
     id 'com.android.application' version '7.3.0' apply false
     id 'com.android.library' version '7.3.0' apply false


### PR DESCRIPTION
### **PR対応内容**

- アプリを立ち上げドップ画面を表示
- 画面中央にAPIを実装した際に、Googleアカウントにサインインする処理を追加するボタンを実装
（現時点では、何の処理も施されていません。）
- トップ画面に二つのボタンを追加
- 二つのボタンからそれぞれ他画面に遷移（仮デザイン）
- build.gradleファイルにAPI連携のためのライブラリを追加（まだ実装に至っていないため、コメントアウト）

### **動作確認内容**

- アプリがビルドできる
- ボタンを押したらそれぞれ画面遷移する

### **仕様について**
https://docs.google.com/document/d/19uUf7Ia7pgHdqHkRsN2suzQyXPTUj2zFbppwIG9o1rA/edit?usp=sharing
